### PR TITLE
ci: Remove deprecated set-output usage

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,7 +28,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       - run: |
-          echo ::set-output name=short::$(git rev-parse --short=7 ${{ github.sha }})
+          echo short=$(git rev-parse --short=7 ${{ github.sha }}) >> $GITHUB_OUTPUT
         id: git
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
## Overview

`set-output` is being deprecated and will cause failures June 2023. Updated to the recommended approach.

## Reference

- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.com/Doist/infrastructure-backlog/issues/481

