### PR TITLE
feat: build docker image on ARM

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,5 +49,7 @@ jobs:
           cache-to: type=inline
           tags: |
             ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+          platforms: linux/amd64,linux/arm64
+
         env:
           VERSION: ${{ steps.git.outputs.short }}


### PR DESCRIPTION
This change will build redis-cluster-mock docker container for AMD64 and ARM64 platforms for local development

On Apple Silicon MacBooks (M{1..3}) twist fails to spin up a local environment due to the fact that `redis-cluster-mock ` doesn’t have a ARM64 docker image available. Although we could pick an AMD64 image and should work, [this has not been the case](https://github.com/Doist/Twist/pull/2870#pullrequestreview-2091443850), so we pivot to the idea to build our dev containers on both platforms. 