### PR TITLE
Tag image as latest too

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,6 +49,7 @@ jobs:
           cache-to: type=inline
           tags: |
             ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+            ${{ env.IMAGE_NAME }}:latest
           platforms: linux/amd64,linux/arm64
 
         env:


### PR DESCRIPTION
So that we can automatically pull it without having to update repos that use it.

Closes #8.